### PR TITLE
fix: remove duplicate Header/Footer components from pages

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,8 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import Header from '@/components/Header';
-import Footer from '@/components/Footer';
 import { UserPreferences } from '@/types/workout';
 
 const STORAGE_KEY = 'aiWorkoutPro_userPreferences';
@@ -70,8 +68,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
-      <Header />
+    <div className="bg-gradient-to-br from-blue-50 via-white to-purple-50">
       
       <main className="py-12 px-4 sm:px-6 lg:px-8">
         <div className="container mx-auto max-w-4xl">
@@ -300,8 +297,6 @@ export default function SettingsPage() {
           </div>
         </div>
       </main>
-
-      <Footer />
     </div>
   );
 }

--- a/src/app/workout/page.tsx
+++ b/src/app/workout/page.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import Header from '@/components/Header';
-import Footer from '@/components/Footer';
 import { BodyPart, WorkoutGeneration } from '@/types/workout';
 import { workoutGenerator } from '@/lib/workout-generator';
 
@@ -133,8 +131,7 @@ export default function WorkoutPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
-      <Header />
+    <div className="bg-gradient-to-br from-blue-50 via-white to-purple-50">
       
       <main className="py-12 px-4 sm:px-6 lg:px-8">
         <div className="container mx-auto max-w-6xl">
@@ -378,8 +375,6 @@ export default function WorkoutPage() {
           </div>
         </div>
       </main>
-
-      <Footer />
     </div>
   );
 }

--- a/src/app/workout/result/page.tsx
+++ b/src/app/workout/result/page.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import Header from '@/components/Header';
-import Footer from '@/components/Footer';
 import { WorkoutMenu, Exercise } from '@/types/workout';
 import { workoutGenerator } from '@/lib/workout-generator';
 
@@ -84,7 +82,7 @@ export default function WorkoutResultPage() {
 
   if (!workoutMenu) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center">
+      <div className="bg-gradient-to-br from-blue-50 via-white to-purple-50 flex items-center justify-center min-h-[400px]">
         <div className="text-center">
           <div className="w-16 h-16 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
           <p className="text-gray-600">ワークアウトを読み込み中...</p>
@@ -94,8 +92,7 @@ export default function WorkoutResultPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
-      <Header />
+    <div className="bg-gradient-to-br from-blue-50 via-white to-purple-50">
       
       <main className="py-8 px-4 sm:px-6 lg:px-8">
         <div className="container mx-auto max-w-4xl">
@@ -317,8 +314,6 @@ export default function WorkoutResultPage() {
           </div>
         </div>
       </main>
-
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #23 - Remove duplicate Header/Footer components that were causing double display

## Changes
- Remove duplicate Header/Footer imports and usage from workout, settings, and workout result pages
- Layout.tsx already provides Header/Footer for all pages, eliminating duplication
- Fixes issue where header/footer were displaying twice on these pages

## Files Modified
- src/app/workout/page.tsx
- src/app/settings/page.tsx
- src/app/workout/result/page.tsx

## Testing
- Visit /workout and /settings pages to verify header/footer only display once
- Check /workout/result page as well


Generated with [Claude Code](https://claude.ai/code)