### PR TITLE
fix: downgrade Tailwind CSS v4 to v3 for Vercel compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,17 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0", 
     "@types/node": "^20.17.52",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "autoprefixer": "^10.4.16",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "jest-environment-jsdom": "^30.0.0-beta.3",
-    "tailwindcss": "^4",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.0",
     "typescript": "^5"
   }
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,8 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
 
 export default config;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,15 +1,10 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;
   --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,21 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+      },
+      fontFamily: {
+        sans: 'var(--font-geist-sans)',
+        mono: 'var(--font-geist-mono)',
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
Fixes Vercel build error by downgrading from Tailwind CSS v4 to v3

## Problem
Vercel deployment was failing with:
```
Error: Cannot find module '../lightningcss.linux-x64-gnu.node'
```

## Solution
- Downgraded `tailwindcss` from ^4 to ^3.4.0
- Removed `@tailwindcss/postcss` v4 plugin
- Added `autoprefixer` and `postcss` dependencies
- Created `tailwind.config.js` with v3 configuration
- Updated `globals.css` to use standard @tailwind directives
- Updated `postcss.config.mjs` to use standard plugins

## Testing
- All existing styles should continue to work
- Vercel build should now succeed without lightningcss errors

Fixes #25

Generated with [Claude Code](https://claude.ai/code)