### PR TITLE
fix: Add null safety for optional Firestore ID fields

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -41,7 +41,7 @@ export default function DashboardPage() {
 
   // Helper functions to convert between Firestore and component data formats
   const convertFirestoreSessionToComponent = (firestoreSession: import('@/lib/firestore').WorkoutSession): WorkoutSession => ({
-    id: firestoreSession.id,
+    id: firestoreSession.id || '',
     user_id: firestoreSession.userId,
     title: firestoreSession.title,
     target_muscles: firestoreSession.targetMuscles,
@@ -56,7 +56,7 @@ export default function DashboardPage() {
   })
 
   const convertFirestoreFavoriteToComponent = (firestoreFavorite: import('@/lib/firestore').FavoriteWorkout): FavoriteWorkout => ({
-    id: firestoreFavorite.id,
+    id: firestoreFavorite.id || '',
     user_id: firestoreFavorite.userId,
     workout_data: firestoreFavorite.workoutData,
     title: firestoreFavorite.title,

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -17,7 +17,7 @@ export default function FavoritesPage() {
 
   // Helper function to convert Firestore favorite to component format
   const convertFirestoreFavoriteToComponent = (firestoreFavorite: import('@/lib/firestore').FavoriteWorkout): FavoriteWorkout => ({
-    id: firestoreFavorite.id,
+    id: firestoreFavorite.id || '',
     user_id: firestoreFavorite.userId,
     workout_data: firestoreFavorite.workoutData,
     title: firestoreFavorite.title,

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -18,7 +18,7 @@ export default function HistoryPage() {
 
   // Helper function to convert Firestore session to component format
   const convertFirestoreSessionToComponent = (firestoreSession: import('@/lib/firestore').WorkoutSession): WorkoutSession => ({
-    id: firestoreSession.id,
+    id: firestoreSession.id || '',
     user_id: firestoreSession.userId,
     title: firestoreSession.title,
     target_muscles: firestoreSession.targetMuscles,


### PR DESCRIPTION
Fix TypeScript build error where `firestoreSession.id` (type: `string | undefined`) cannot be assigned to properties expecting `string`.

Applied to all conversion functions in:
- src/app/dashboard/page.tsx: convertFirestoreSessionToComponent and convertFirestoreFavoriteToComponent
- src/app/favorites/page.tsx: convertFirestoreFavoriteToComponent
- src/app/history/page.tsx: convertFirestoreSessionToComponent

Uses `|| ''` fallback to maintain type safety while handling edge cases.

Fixes #41

Generated with [Claude Code](https://claude.ai/code)