### PR TITLE
fix: prevent hydration mismatch on body element

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,6 +42,7 @@ export default function RootLayout({
     <html lang="ja">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning={true}
       >
         <AuthProvider>
           <div className="min-h-screen flex flex-col">


### PR DESCRIPTION
This PR fixes the React hydration mismatch error caused by VS Code extensions adding dynamic className changes to the body element.

## Changes
- Added `suppressHydrationWarning={true}` to body element in src/app/layout.tsx
- Prevents hydration mismatch errors from `vsc-initialized` and other extension classes
- Maintains consistent SSR behavior while allowing client-side modifications

## Issue
Closes #59

Generated with [Claude Code](https://claude.ai/code)