### PR TITLE
feat: expand exercise translation dictionary for better DALL-E image generation

### DIFF
--- a/src/app/api/generate-workout/route.ts
+++ b/src/app/api/generate-workout/route.ts
@@ -150,9 +150,12 @@ function translateExerciseName(japaneseExerciseName: string): string {
     
     // 脚系
     'スクワット': 'squat',
+    'ボディウェイトスクワット': 'bodyweight squat',
     'ランジ': 'lunge',
     'カーフレイズ': 'calf raise',
+    'スタンディングカーフレイズ': 'standing calf raise',
     'ヒップブリッジ': 'hip bridge',
+    'グルートブリッジ': 'glute bridge',
     'レッグプレス': 'leg press',
     'デッドリフト': 'deadlift',
     


### PR DESCRIPTION
## Summary
- Add グルートブリッジ → glute bridge mapping
- Add ボディウェイトスクワット → bodyweight squat mapping
- Add スタンディングカーフレイズ → standing calf raise mapping

This improves DALL-E 3 image generation by providing more specific exercise names instead of falling back to generic "strength training exercise" prompts.

## Test plan
- [ ] Test workout generation with exercises containing the updated translations
- [ ] Verify DALL-E images are generated with more specific prompts
- [ ] Check that images display correctly in the workout result page

Closes #65

🤖 Generated with [Claude Code](https://claude.ai/code)