### PR TITLE
fix: preserve Stable Diffusion images in frontend display

### DIFF
--- a/src/app/workout/result/page.tsx
+++ b/src/app/workout/result/page.tsx
@@ -76,10 +76,13 @@ export default function WorkoutResultPage() {
     if (!favorites.includes(workoutMenu.id)) {
       try {
         const savedWorkouts = JSON.parse(localStorage.getItem('savedWorkouts') || '{}');
-        // Strip image data before saving to avoid quota issues
+        // Keep base64 data URLs (Stable Diffusion images) but strip external URLs to avoid quota issues
         const workoutToSave = {
           ...workoutMenu,
-          exercises: workoutMenu.exercises.map(ex => ({ ...ex, imageUrl: undefined }))
+          exercises: workoutMenu.exercises.map(ex => ({ 
+            ...ex, 
+            imageUrl: ex.imageUrl?.startsWith('data:') ? ex.imageUrl : undefined 
+          }))
         };
         savedWorkouts[workoutMenu.id] = workoutToSave;
         localStorage.setItem('savedWorkouts', JSON.stringify(savedWorkouts));

--- a/src/lib/storage-utils.ts
+++ b/src/lib/storage-utils.ts
@@ -48,13 +48,15 @@ export class SafeStorage {
 
   /**
    * Remove image data from workout menu to reduce size
+   * Preserves base64 data URLs from Stable Diffusion but removes external URLs
    */
   private static stripImageData(menu: WorkoutMenu): WorkoutMenu {
     return {
       ...menu,
       exercises: menu.exercises.map(exercise => ({
         ...exercise,
-        imageUrl: undefined // Remove image URLs to save space
+        // Keep base64 data URLs (Stable Diffusion images) but remove external URLs
+        imageUrl: exercise.imageUrl?.startsWith('data:') ? exercise.imageUrl : undefined
       }))
     };
   }
@@ -266,7 +268,7 @@ export class SafeStorage {
 export const storageUtils = {
   saveWorkout: (menu: WorkoutMenu): StorageResult<WorkoutMenu> => {
     return SafeStorage.setItem('generatedWorkout', menu, { 
-      stripImages: true,
+      stripImages: false, // Keep base64 Stable Diffusion images
       useSessionStorage: true 
     });
   },


### PR DESCRIPTION
## Summary
- Fix Stable Diffusion image display issue on frontend
- Preserve base64 data URLs in storage while removing external URLs
- Update storage utility and favorites saving logic

## Problem
Stable Diffusion image generation was working on API side, but images weren't displaying on frontend because:
- Storage utility was automatically stripping ALL image URLs
- This included base64 data URLs from Stable Diffusion
- Frontend showed placeholders instead of generated images

## Solution
- Modified `stripImageData` to preserve base64 data URLs (`data:` protocol)
- Updated `saveWorkout` to not strip images by default
- Fixed favorites saving to retain generated images

## Test plan
- [ ] Generate workout with image generation enabled
- [ ] Verify Stable Diffusion images display in exercise sections
- [ ] Check that favorited workouts retain images
- [ ] Confirm storage quota isn't exceeded with base64 images

Closes #65

🤖 Generated with [Claude Code](https://claude.ai/code)